### PR TITLE
Flexible HTTP-Auth-Methoden

### DIFF
--- a/config/camera_models.dat
+++ b/config/camera_models.dat
@@ -1,4 +1,7 @@
-1|Trendnet|TV-IP310PI|/Streaming/channels/1/picture
-2|Trendnet|TV-IP302PI|/GetImage.cgi
-3|Digitus|DN-16049|/web/cgi-bin/hi3510/snap.cgi?&-getpic
-4|Axis|M3024-L|/jpg/image.jpg
+1|Trendnet|TV-IP310PI|/Streaming/channels/1/picture|CURLAUTH_DIGEST
+2|Trendnet|TV-IP302PI|/GetImage.cgi|CURLAUTH_DIGEST
+3|Digitus|DN-16049|/web/cgi-bin/hi3510/snap.cgi?&-getpic|CURLAUTH_DIGEST
+4|Axis|M3024-L|/jpg/image.jpg|CURLAUTH_DIGEST
+5|Hikvision|DS-2CD2132|/Streaming/channels/1/picture|CURLAUTH_ANY
+6|Hikvision|DS-2CD2532|/Streaming/channels/1/picture|CURLAUTH_ANY
+7|Hikvision|Generic|/Streaming/channels/1/picture|CURLAUTH_ANY

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -47,7 +47,8 @@ mkdir -p /tmp/uploads/$ARGV1\_upgrade/config
 mkdir -p /tmp/uploads/$ARGV1\_upgrade/log
 
 echo "<INFO> Backing up existing config files"
-cp -v -r $ARGV5/config/plugins/$ARGV3/ /tmp/uploads/$ARGV1\_upgrade/config
+# Avoid backing up camera_models.dat here
+cp -v -r $ARGV5/config/plugins/$ARGV3/cam-connect.cfg /tmp/uploads/$ARGV1\_upgrade/config
 
 echo "<INFO> Backing up existing log files"
 cp -v -r $ARGV5/log/plugins/$ARGV3/ /tmp/uploads/$ARGV1\_upgrade/log

--- a/webfrontend/html/index.php
+++ b/webfrontend/html/index.php
@@ -97,10 +97,11 @@ if ($cam_models_handle)
   {
     $line_of_text = fgets($cam_models_handle);
     $config_line = explode('|', $line_of_text);
-    if (count($config_line) == 4)
+    if (count($config_line) == 5)
     {
       if (intval($config_line[0]) == $cam_model)
       {
+        $plugin_cfg['httpauth'] = $config_line[4];
         $plugin_cfg['imagepath'] = $config_line[3];
         $plugin_cfg['model']     = $config_line[2];
         break;
@@ -153,7 +154,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 {
   $curl = curl_init();
   curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+  curl_setopt($curl, CURLOPT_HTTPAUTH, $plugin_cfg['httpauth']);
   curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
   curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
   curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);
@@ -172,7 +173,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 // Init and config cURL
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+curl_setopt($curl, CURLOPT_HTTPAUTH, $plugin_cfg['httpauth']);
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
 curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
 curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);

--- a/webfrontend/html/index.php
+++ b/webfrontend/html/index.php
@@ -96,6 +96,7 @@ if ($cam_models_handle)
   while (!feof($cam_models_handle))
   {
     $line_of_text = fgets($cam_models_handle);
+    $line_of_text = preg_replace('/\r?\n|\r/','', $line_of_text);
     $config_line = explode('|', $line_of_text);
     if (count($config_line) == 5)
     {
@@ -154,7 +155,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 {
   $curl = curl_init();
   curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($curl, CURLOPT_HTTPAUTH, $plugin_cfg['httpauth']);
+  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
   curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
   curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
   curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);
@@ -174,6 +175,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($curl, CURLOPT_HTTPAUTH, $plugin_cfg['httpauth']);
+#curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
 curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
 curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);
@@ -220,7 +222,7 @@ if(mb_strlen($picture) < 500)
   $text_color       = ImageColorAllocate ($error_image, 255, 64, 64);
   ImageString ($error_image,20, 10, 10, $error_msg, $text_color);
   $text_color       = ImageColorAllocate ($error_image, 0, 0, 255);
-  $error_msg = "URL: ".$plugin_cfg['url'];
+  $error_msg = "URL: ".$plugin_cfg['url']."  HTTPAUTH: ".$plugin_cfg['httpauth'];
   ImageString ($error_image, 20, 10, 50, $error_msg, $text_color);
   $text_color       = ImageColorAllocate ($error_image, 128,128,128);
   $line = 70;

--- a/webfrontend/html/index.php
+++ b/webfrontend/html/index.php
@@ -155,7 +155,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 {
   $curl = curl_init();
   curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+  curl_setopt($curl, CURLOPT_HTTPAUTH, constant($plugin_cfg['httpauth']));
   curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
   curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
   curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);
@@ -174,8 +174,7 @@ if ( $plugin_cfg['model'] == "DN-16049" )
 // Init and config cURL
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($curl, CURLOPT_HTTPAUTH, $plugin_cfg['httpauth']);
-#curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+curl_setopt($curl, CURLOPT_HTTPAUTH, constant($plugin_cfg['httpauth']));
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
 curl_setopt($curl, CURLOPT_USERPWD, $plugin_cfg['user'].":".$plugin_cfg['pass']);
 curl_setopt($curl, CURLOPT_URL, $plugin_cfg['url']);

--- a/webfrontend/html/stream.php
+++ b/webfrontend/html/stream.php
@@ -1,0 +1,45 @@
+<?
+#
+# Stream Pictures from IP-CAM as MJPEG Stream
+#
+# Code from here:
+# http://ben-collins.blogspot.de/2010/06/php-sending-motion-jpeg.html
+#
+
+# Used to separate multipart
+$boundary = "my_mjpeg";
+
+# We start with the standard headers. PHP allows us this much
+header("Cache-Control: no-cache");
+header("Cache-Control: private");
+header("Pragma: no-cache");
+header("Content-type: multipart/x-mixed-replace; boundary=$boundary");
+
+# From here out, we no longer expect to be able to use the header() function
+print "--$boundary\n";
+
+# Set this so PHP doesn't timeout during a long stream
+set_time_limit(0);
+
+# Disable Apache and PHP's compression of output to the client
+@apache_setenv('no-gzip', 1);
+@ini_set('zlib.output_compression', 0);
+
+# Set implicit flush, and flush all current buffers
+@ini_set('implicit_flush', 1);
+for ($i = 0; $i < ob_get_level(); $i++)
+    ob_end_flush();
+ob_implicit_flush(1);
+
+# The loop, producing one jpeg frame per iteration
+while (true) {
+    # Per-image header, note the two new-lines
+    print "Content-type: image/jpeg\n\n";
+
+    # Your function to get one jpeg image
+    include ("index.php"); ?>
+
+    # The separator
+    print "--$boundary\n";
+}
+?>


### PR DESCRIPTION
Ich habe versucht flexible HTTP-AUTH-Typen zu integrierne (ich brauche für meine Cam HTTP-AUTH Basic). Das kann zwar LoxConfig, aber ich nutze vom Plugin die ImageResize-Funktion.

Leider funktioniert es noch nicht. Schau mal in index.php in Zeile 177. Dort setze ich die AUTH-Methode aus der neuen camera-models.dat. Aber es will nicht funktionieren, obwohl in der Variablen $plugin_cfg['httpauth'] die richtige Methode hinterlegt ist. Code ich sie fix hinein (Zeile 178), dann geht es... Vermutlich irgend ein String, Integer, NewLine oder sonstwas-Problem. Aber ich finde es einfach nicht.

Dann würde ich gerne noch eine Funktion einbauen aus den Webcam-Pictures einen MJPEG-Stream zu bauen (siehe dazu stream.php). Da müsste man irgendwie in Zeile 40 noch den korrekten Aufruf von index.php mit einbauen. Da bin ich aber noch nicht soweit.